### PR TITLE
feat: 유저엔티티 생성

### DIFF
--- a/src/main/java/com/wanted/socialintegratefreed/domain/user/constant/UserEnable.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/user/constant/UserEnable.java
@@ -1,0 +1,14 @@
+package com.wanted.socialintegratefreed.domain.user.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserEnable {
+    USER_ENABLED("활성화"),
+    USER_DISABLED("비활성화");
+    private String enable;
+
+
+}

--- a/src/main/java/com/wanted/socialintegratefreed/domain/user/constant/UserEnable.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/user/constant/UserEnable.java
@@ -5,10 +5,16 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+/**
+ * UserEnable: 로그인 여부
+ */
 public enum UserEnable {
+    /**
+     * @USER_ENABLED : 가입 여부 활성화
+     * @USER_DISABLED : 가입 여부 비활성화
+     */
     USER_ENABLED("활성화"),
     USER_DISABLED("비활성화");
     private String enable;
-
 
 }

--- a/src/main/java/com/wanted/socialintegratefreed/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/user/dao/UserRepository.java
@@ -1,0 +1,10 @@
+package com.wanted.socialintegratefreed.domain.user.dao;
+
+
+import com.wanted.socialintegratefreed.domain.user.entity.User;
+import jakarta.persistence.Id;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Id> {
+
+}

--- a/src/main/java/com/wanted/socialintegratefreed/domain/user/entity/BaseTimeEntity.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/user/entity/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.wanted.socialintegratefreed.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "createdAt")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updatedAt")
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/wanted/socialintegratefreed/domain/user/entity/User.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/user/entity/User.java
@@ -1,0 +1,43 @@
+package com.wanted.socialintegratefreed.domain.user.entity;
+
+
+import com.wanted.socialintegratefreed.domain.user.constant.UserEnable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "user")
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+    @Column(name = "password", nullable = false)
+    private String password;
+    @Column(name = "enabled")
+    @Enumerated(EnumType.STRING)
+    private UserEnable userEnable;
+
+    @Builder
+    public User(Long userId, String email, String password) {
+        this.userId = userId;
+        this.email = email;
+        this.password = password;
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #2 

## 📝 Description

User 및 BaseTimeEntity 생성 이후 기본적인 틀을 잡았습니다. 

`유저` 로그인시 `가입여부` 가 있기 때문에  `Enum`으로 따로 만들어 Colum을 `설정` 하였습니다. 