### PR TITLE
Feature/#7 게시물 관련 entity 및 repository생성

### DIFF
--- a/src/main/java/com/wanted/socialintegratefreed/domain/feed/constant/FeedType.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/feed/constant/FeedType.java
@@ -1,0 +1,9 @@
+package com.wanted.socialintegratefreed.domain.feed.constant;
+
+/**
+ * 게시물 타입  Enum
+ */
+public enum FeedType {
+  FACEBOOK, TWITTER, INSTAGRAM, THREADS
+
+}

--- a/src/main/java/com/wanted/socialintegratefreed/domain/feed/dao/FeedRepository.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/feed/dao/FeedRepository.java
@@ -1,0 +1,8 @@
+package com.wanted.socialintegratefreed.domain.feed.dao;
+
+import com.wanted.socialintegratefreed.domain.feed.entity.Feed;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedRepository extends JpaRepository<Feed, Long> {
+
+}

--- a/src/main/java/com/wanted/socialintegratefreed/domain/feed/entity/Feed.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/feed/entity/Feed.java
@@ -15,8 +15,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -73,7 +73,7 @@ public class Feed extends BaseTimeEntity {
 
   // 'TagMatching'엔티티와 일대다 관계 설정
   @OneToMany(mappedBy = "feed")
-  private Set<TagMatching> tagMatchings = new HashSet<>();
+  private List<TagMatching> tagMatchings = new ArrayList<>();
 
   @Builder
   public Feed(String title, String content, Integer viewCount, Integer likeCount, Integer shareCount, FeedType type, User user) {

--- a/src/main/java/com/wanted/socialintegratefreed/domain/feed/entity/Feed.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/feed/entity/Feed.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -67,7 +68,7 @@ public class Feed extends BaseTimeEntity {
   private FeedType type;
 
   // 'User'엔티티 와의 다대일 관계 설정
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")
   private User user;
 

--- a/src/main/java/com/wanted/socialintegratefreed/domain/feed/entity/Feed.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/feed/entity/Feed.java
@@ -1,0 +1,88 @@
+package com.wanted.socialintegratefreed.domain.feed.entity;
+
+import com.wanted.socialintegratefreed.domain.feed.constant.FeedType;
+import com.wanted.socialintegratefreed.domain.tagmatching.entity.TagMatching;
+import com.wanted.socialintegratefreed.domain.user.entity.User;
+import com.wanted.socialintegratefreed.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+/**
+ * 게시물 엔티티
+ */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "feed")
+public class Feed extends BaseTimeEntity {
+
+  // 게시물 ID
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "feed_id", nullable = false)
+  private Long feedId;
+
+  // 게시글 제목
+  @Column(name = "title", length = 128, nullable = false)
+  private String title;
+
+  // 게시글 내용
+  @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+  private String content;
+
+  // 조회 수
+  @Column(name = "view_count", nullable = false)
+  @ColumnDefault(value = "0")
+  private Integer viewCount;
+
+  // 좋아요 수
+  @Column(name = "like_count", nullable = false)
+  @ColumnDefault(value = "0")
+  private Integer likeCount;
+
+  // 공유 수
+  @Column(name = "share_count", nullable = false)
+  @ColumnDefault(value = "0")
+  private Integer shareCount;
+
+  // 게시물 타입
+  @Column(name = "type", nullable = false)
+  @Enumerated(EnumType.STRING)
+  private FeedType type;
+
+  // 'User'엔티티 와의 다대일 관계 설정
+  @ManyToOne
+  @JoinColumn(name = "user_id")
+  private User user;
+
+  // 'TagMatching'엔티티와 일대다 관계 설정
+  @OneToMany(mappedBy = "feed")
+  private Set<TagMatching> tagMatchings = new HashSet<>();
+
+  @Builder
+  public Feed(String title, String content, Integer viewCount, Integer likeCount, Integer shareCount, FeedType type, User user) {
+    this.title = title;
+    this.content = content;
+    this.viewCount = viewCount;
+    this.likeCount = likeCount;
+    this.shareCount = shareCount;
+    this.type = type;
+    this.user = user;
+  }
+}

--- a/src/main/java/com/wanted/socialintegratefreed/domain/hashtag/dao/HashtagRepository.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/hashtag/dao/HashtagRepository.java
@@ -1,0 +1,8 @@
+package com.wanted.socialintegratefreed.domain.hashtag.dao;
+
+import com.wanted.socialintegratefreed.domain.hashtag.entity.Hashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+
+}

--- a/src/main/java/com/wanted/socialintegratefreed/domain/hashtag/entity/Hashtag.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/hashtag/entity/Hashtag.java
@@ -9,8 +9,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,7 +36,7 @@ public class Hashtag extends BaseTimeEntity {
 
   // 'TagMatching'엔티티와 일대다 관계 설정
   @OneToMany(mappedBy = "hashtag")
-  private Set<TagMatching> tagMatchings = new HashSet<>();
+  private List<TagMatching> tagMatchings = new ArrayList<>();
 
   @Builder
   public Hashtag(String name) {

--- a/src/main/java/com/wanted/socialintegratefreed/domain/hashtag/entity/Hashtag.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/hashtag/entity/Hashtag.java
@@ -1,0 +1,45 @@
+package com.wanted.socialintegratefreed.domain.hashtag.entity;
+
+import com.wanted.socialintegratefreed.domain.tagmatching.entity.TagMatching;
+import com.wanted.socialintegratefreed.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 해시태그 엔티티
+ */
+@Entity
+@NoArgsConstructor
+@Getter
+@Table(name = "hashtag")
+public class Hashtag extends BaseTimeEntity {
+
+  // 해시태그 ID
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "hashtag_id", nullable = false)
+  private Long hashtagId;
+
+  // 해시태그 이름
+  @Column(name = "name", length = 30, nullable = false)
+  private String name;
+
+  // 'TagMatching'엔티티와 일대다 관계 설정
+  @OneToMany(mappedBy = "hashtag")
+  private Set<TagMatching> tagMatchings = new HashSet<>();
+
+  @Builder
+  public Hashtag(String name) {
+    this.name = name;
+  }
+}

--- a/src/main/java/com/wanted/socialintegratefreed/domain/tagmatching/dao/TagMatchingRepository.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/tagmatching/dao/TagMatchingRepository.java
@@ -1,0 +1,8 @@
+package com.wanted.socialintegratefreed.domain.tagmatching.dao;
+
+import com.wanted.socialintegratefreed.domain.tagmatching.entity.TagMatching;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagMatchingRepository extends JpaRepository<TagMatching, Long> {
+
+}

--- a/src/main/java/com/wanted/socialintegratefreed/domain/tagmatching/entity/TagMatching.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/tagmatching/entity/TagMatching.java
@@ -1,0 +1,53 @@
+package com.wanted.socialintegratefreed.domain.tagmatching.entity;
+
+import com.wanted.socialintegratefreed.domain.feed.entity.Feed;
+import com.wanted.socialintegratefreed.domain.hashtag.entity.Hashtag;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
+
+
+/**
+ * `hashtag`, `feed` 엔티티와의 다대다 관계를 일대다 - 다대일 관계로 매핑하기 위한 중간 엔티티
+ */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "tag_matching")
+public class TagMatching {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "tag_matching_id", nullable = false)
+  private Long tagMatchingId;
+
+  // 부모 엔티티인 'Feed'와의 관계 설정
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "feed_id")
+  @Cascade({CascadeType.PERSIST, CascadeType.MERGE, CascadeType.DETACH, CascadeType.REFRESH})
+  private Feed feed;
+
+  // 부모 엔티티인 'Hashtag'와의 관계 설정
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "hashtag_id")
+  @Cascade({CascadeType.PERSIST, CascadeType.MERGE, CascadeType.DETACH, CascadeType.REFRESH})
+  private Hashtag hashtag;
+
+  @Builder
+  public TagMatching(Feed feed, Hashtag hashtag) {
+    this.feed = feed;
+    this.hashtag = hashtag;
+  }
+}

--- a/src/main/java/com/wanted/socialintegratefreed/domain/tagmatching/entity/TagMatching.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/tagmatching/entity/TagMatching.java
@@ -36,13 +36,13 @@ public class TagMatching {
   // 부모 엔티티인 'Feed'와의 관계 설정
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "feed_id")
-  @Cascade({CascadeType.PERSIST, CascadeType.MERGE, CascadeType.DETACH, CascadeType.REFRESH})
+  @Cascade(CascadeType.ALL)
   private Feed feed;
 
   // 부모 엔티티인 'Hashtag'와의 관계 설정
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "hashtag_id")
-  @Cascade({CascadeType.PERSIST, CascadeType.MERGE, CascadeType.DETACH, CascadeType.REFRESH})
+  @Cascade(CascadeType.ALL)
   private Hashtag hashtag;
 
   @Builder

--- a/src/main/java/com/wanted/socialintegratefreed/domain/user/entity/User.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/user/entity/User.java
@@ -1,7 +1,7 @@
 package com.wanted.socialintegratefreed.domain.user.entity;
 
-
 import com.wanted.socialintegratefreed.domain.user.constant.UserEnable;
+import com.wanted.socialintegratefreed.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/wanted/socialintegratefreed/domain/user/entity/User.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.wanted.socialintegratefreed.domain.user.entity;
 
+import com.wanted.socialintegratefreed.domain.feed.entity.Feed;
 import com.wanted.socialintegratefreed.domain.user.constant.UserEnable;
 import com.wanted.socialintegratefreed.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
@@ -9,7 +10,10 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,6 +37,10 @@ public class User extends BaseTimeEntity {
     @Column(name = "enabled")
     @Enumerated(EnumType.STRING)
     private UserEnable userEnable;
+
+    // 'Feed'엔티티와 일대다 관계 설정
+    @OneToMany(mappedBy = "user")
+    private List<Feed> feeds = new ArrayList<>();
 
     @Builder
     public User(Long userId, String email, String password) {

--- a/src/main/java/com/wanted/socialintegratefreed/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/wanted/socialintegratefreed/global/entity/BaseTimeEntity.java
@@ -1,4 +1,4 @@
-package com.wanted.socialintegratefreed.domain.user.entity;
+package com.wanted.socialintegratefreed.global.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;


### PR DESCRIPTION
## 🔥 Related Issue

close: #7

## 📝 Description

#2 에서 생성한 `BaseTimeEntiy`의 경로를 `...\global\entity\`  경로로 이동하였습니다.
게시물 관련 엔티티인 `Feed`, `HashTag`, `TagMatching` 클래스를 생성하였고, 해당 dao도 생성하였습니다.
테이블 간의 연관 관계 설정을 하였습니다.
