### PR TITLE
Fix/#25 게시물 생성 수정을 위한 dto 검증 수정

### DIFF
--- a/src/main/java/com/wanted/socialintegratefreed/domain/feed/api/FeedController.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/feed/api/FeedController.java
@@ -40,7 +40,7 @@ public class FeedController {
       @RequestBody @Valid FeedCreateRequest request
   ) {
     //사용자 조회
-    User user = userService.getUserById(request.getUserId());
+    User user = userService.findUserIdReturnUser(request.getUserId());
 
     //생성한 게시글 ID 반환
     Long createdFeedId = feedService.createFeed(request,user);
@@ -66,7 +66,7 @@ public class FeedController {
       @RequestBody @Valid FeedUpdateRequest request
   ) {
     //사용자 조회
-    User user = userService.getUserById(request.getUserId());
+    User user = userService.findUserIdReturnUser(request.getUserId());
 
     //게시물 수정
     feedService.updateFeed(feedId, request, user);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ server:
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/01_socialintegratefeed?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://localhost:3306/01_socialintegratefeed?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: root
     password: root
 

--- a/src/test/java/com/wanted/socialintegratefreed/domain/feed/api/FeedControllerTest.java
+++ b/src/test/java/com/wanted/socialintegratefreed/domain/feed/api/FeedControllerTest.java
@@ -10,6 +10,7 @@ import com.wanted.socialintegratefreed.domain.feed.entity.Feed;
 import com.wanted.socialintegratefreed.domain.user.application.UserService;
 
 import com.wanted.socialintegratefreed.domain.user.entity.User;
+import com.wanted.socialintegratefreed.domain.user.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,6 +39,9 @@ public class FeedControllerTest extends AbstractRestDocsTests {
 
   @Autowired
   private WebApplicationContext context;
+
+  @MockBean
+  private JwtTokenProvider jwtTokenProvider;
 
   @MockBean
   private FeedService feedService;


### PR DESCRIPTION
## 🔥 Related Issue

close: #25 

## 📝 Description

1. 게시물 생성 수정을 위한 dto 검증 보완 작업 후 테스트 완료했습니다.

2. 추가적으로 이전에 조언해주신 부분 리팩토링 작업 진행했습니다.
- FeedController 
   - 주석 상태코드 200 이런식으로 구체화
   - 파라미터 개행 
   - 결과값 생성, 수정, 삭제 할 때 feed id return 하도록 수정
- FeedService
   - findById 중복코드 따로 메소드 분리 작업
- Feed
   - update 메소드 삼항연산자 사용하도록 리팩토링

## ⭐️ Review

제가 이전에 너무 급하게 하느라 빠뜨린 부분이 많네요ㅠ.ㅠ
merge할 때도 실수한 부분이 있는데 선재님이 잘 병합해주신거같아서 저는 이번에 충돌이 안났어요 정말 감사드려요
혹시 또 보완해야할 부분 수정해야할 부분 말씀부탁드립니닷 🙏