### PR TITLE
Fix/#25 게시물 생성 수정을 위한 dto 검증 수정

### DIFF
--- a/src/main/java/com/wanted/socialintegratefreed/domain/feed/api/FeedController.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/feed/api/FeedController.java
@@ -40,7 +40,7 @@ public class FeedController {
       @RequestBody @Valid FeedCreateRequest request
   ) {
     //사용자 조회
-    User user = userService.getUserById(request.getUserId());
+    User user = userService.findUserIdReturnUser(request.getUserId());
 
     //생성한 게시글 ID 반환
     Long createdFeedId = feedService.createFeed(request,user);
@@ -66,7 +66,7 @@ public class FeedController {
       @RequestBody @Valid FeedUpdateRequest request
   ) {
     //사용자 조회
-    User user = userService.getUserById(request.getUserId());
+    User user = userService.findUserIdReturnUser(request.getUserId());
 
     //게시물 수정
     feedService.updateFeed(feedId, request, user);

--- a/src/test/java/com/wanted/socialintegratefreed/domain/feed/api/FeedControllerTest.java
+++ b/src/test/java/com/wanted/socialintegratefreed/domain/feed/api/FeedControllerTest.java
@@ -10,6 +10,7 @@ import com.wanted.socialintegratefreed.domain.feed.entity.Feed;
 import com.wanted.socialintegratefreed.domain.user.application.UserService;
 
 import com.wanted.socialintegratefreed.domain.user.entity.User;
+import com.wanted.socialintegratefreed.domain.user.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,6 +39,9 @@ public class FeedControllerTest extends AbstractRestDocsTests {
 
   @Autowired
   private WebApplicationContext context;
+
+  @MockBean
+  private JwtTokenProvider jwtTokenProvider;
 
   @MockBean
   private FeedService feedService;


### PR DESCRIPTION
## 🔥 Related Issue

close: #25 

## 📝 Description

1. 게시물 생성 수정을 위한 dto 검증 보완 작업 후 테스트 완료했습니다.

2. 추가적으로 이전에 조언해주신 부분 리팩토링 작업 진행했습니다.
- FeedController 
   - 주석 상태코드 200 이런식으로 구체화
   - 파라미터 개행 
   - 결과값 생성, 수정, 삭제 할 때 feed id return 하도록 수정
- FeedService
   - findById 중복코드 따로 메소드 분리 작업
- Feed
   - update 메소드 삼항연산자 사용하도록 리팩토링

## ⭐️ Review

제가 이전에 너무 급하게 하느라 빠뜨린 부분이 많네요ㅠ.ㅠ
merge할 때도 실수한 부분이 있는데 선재님이 잘 병합해주신거같아서 저는 이번에 충돌이 안났어요 정말 감사드려요
혹시 또 보완해야할 부분 수정해야할 부분 말씀부탁드립니닷 🙏

++

1. develop pull
2. 새로운 브랜치 25 생성
3. 기능 수정
4. develop 로 이동
5. 25 랑 develop이랑 merge
6. 반대로 바뀌었다는 것을 깨닫고 다시 25로 이동
7. develop이랑 25 브랜치랑 merge
8. 테스트하다 오류 발생해서 기능 수정
9. 25브랜치 push

이렇게 했더니 8번에서 수정된 항목만 pr이 되서 close하고 다시 올리려고 했는데 아무리해도 이전 수정한 내역이 포함이 안되서 보니까

원격 develop에 이미 merge 되어서 그렇더라구요ㅠ.ㅠ 왜 그런거죠ㅠㅠ?
그래서 지금 이 부분이라도 올리겠습니다 제가 git이 너무 미숙해서 죄송해요 주의한다고 하고 공부도 했는데 아직 너무 부족한거같습니다.. 혹시 왜이런지 아시는분 알려주세요ㅠㅠ