### PR TITLE
Fix/#38 feed repository test 수정

### DIFF
--- a/src/main/java/com/wanted/socialintegratefreed/domain/user/dto/request/UserRequestAuthCodeDto.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/user/dto/request/UserRequestAuthCodeDto.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 
 /**
@@ -11,6 +12,7 @@ import lombok.Getter;
  */
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 @Builder
 public class UserRequestAuthCodeDto {
 

--- a/src/main/java/com/wanted/socialintegratefreed/domain/user/dto/request/UserSignUpRequestDto.java
+++ b/src/main/java/com/wanted/socialintegratefreed/domain/user/dto/request/UserSignUpRequestDto.java
@@ -9,12 +9,14 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * 회원가입 할때 사용하는 dto
  */
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 @Builder
 public class UserSignUpRequestDto {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ server:
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/01_socialintegratefeed?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://localhost:3306/01_socialintegratefeed?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
     username: root
     password: root
 

--- a/src/test/java/com/wanted/socialintegratefreed/domain/feed/api/FeedControllerTest.java
+++ b/src/test/java/com/wanted/socialintegratefreed/domain/feed/api/FeedControllerTest.java
@@ -103,6 +103,7 @@ public class FeedControllerTest extends AbstractRestDocsTests {
                 .userId(1L)
                 .title("수정 제목")
                 .content("수정 내용")
+                .type(FeedType.FACEBOOK)
                 .build();
 
         mockMvc.perform(put("/api/v1/feeds/" + feedId)

--- a/src/test/java/com/wanted/socialintegratefreed/domain/feed/dao/FeedRepositoryTest.java
+++ b/src/test/java/com/wanted/socialintegratefreed/domain/feed/dao/FeedRepositoryTest.java
@@ -19,9 +19,7 @@ import com.wanted.socialintegratefreed.domain.user.dao.UserRepository;
 import com.wanted.socialintegratefreed.domain.user.entity.User;
 import java.time.LocalDateTime;
 import java.util.NoSuchElementException;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -47,12 +45,6 @@ public class FeedRepositoryTest{
 
   private Feed feed;
   private User user;
-
-  @AfterEach
-  public void cleanup() {
-    feedRepository.deleteAll();
-    userRepository.deleteAll();
-  }
 
   @DisplayName("게시글이 성공적으로 저장된다.")
   @Test


### PR DESCRIPTION
## 🔥 Related Issue

close: #38 

## 📝 Description

* FeedRepositoryTest 오류 해결
* UserRepositoryTest 오류 해결
* FeedControllerTest 오류 해결

2개의 RepositoryTest의 경우, jdbc와 연결하지 못하는 문제가 발생했습니다.
yml파일의 jdbc url 설정에 allowPublicKeyRetrieval=true를 추가하여 해결하였습니다.

FeedControllerTest의 경우, 게시물 수정 테스트에서 문제가 발생했습니다.
원인은 게시물 update request의 필수 속성인 Type이 빠졌기 때문이었으며 해당 속성을 빌더 패턴에 추가해 해결했습니다.

---

원래 FeedRepositoryTest만 fix하려고 했는데, 얼결에 3개를 했습니다.
그런데 나머지 UserControllerTest의 경우에는 잘모르겠더라구요..!
인가 인증 담당하신 정훈님이 한번만 봐주실 수 있을까요?!

## ⭐️ Review

여담이지만, 게시물 수정에는 PUT보다는 PATCH가 더 적절한 것 같습니다.
PUT은 입력으로 들어오지 않은 속성은 null로 처리해버리기 때문에, 제목만 수정이나 내용만 수정같은 일부 수정이 불가능합니다.
반면 PATCH는 수정된 부분만 말그대로 패치를 하기 때문에, 이 방법이 더 적절하다고 생각합니다! (수정하지는 않았습니다)